### PR TITLE
Support application config of server session ticket IV and shard

### DIFF
--- a/lib/ssl/src/ssl_config.erl
+++ b/lib/ssl/src/ssl_config.erl
@@ -34,7 +34,8 @@
          get_ticket_lifetime/0,
          get_ticket_store_size/0,
          get_internal_active_n/0,
-         get_internal_active_n/1
+         get_internal_active_n/1,
+         get_session_ticket_iv_shard/0
         ]).
 
 %%====================================================================
@@ -107,6 +108,16 @@ get_internal_active_n(false) ->
             N;
          _  ->
             ?INTERNAL_ACTIVE_N
+    end.
+
+get_session_ticket_iv_shard() ->
+    case {application:get_env(ssl, server_session_ticket_iv),
+          application:get_env(ssl, server_session_ticket_shard)} of
+        {{ok, IV}, {ok, Shard}} when is_binary(IV) andalso bit_size(IV) == 128 andalso
+                                     is_binary(Shard) andalso bit_size(Shard) == 256 ->
+            {IV, Shard};
+        _ ->
+            {crypto:strong_rand_bytes(16), crypto:strong_rand_bytes(32)}
     end.
 
 %%====================================================================

--- a/lib/ssl/src/tls_server_session_ticket.erl
+++ b/lib/ssl/src/tls_server_session_ticket.erl
@@ -150,8 +150,7 @@ format_status(_Opt, Status) ->
 
 inital_state([stateless, Lifetime, _, MaxEarlyDataSize, undefined]) ->
     #state{nonce = 0,
-           stateless = #{seed => {crypto:strong_rand_bytes(16), 
-                                  crypto:strong_rand_bytes(32)},
+           stateless = #{seed => ssl_config:get_session_ticket_iv_shard(),
                          window => undefined},
            lifetime = Lifetime,
            max_early_data_size = MaxEarlyDataSize
@@ -160,8 +159,7 @@ inital_state([stateless, Lifetime, _, MaxEarlyDataSize, {Window, K, M}]) ->
     erlang:send_after(Window * 1000, self(), rotate_bloom_filters),
     #state{nonce = 0,
            stateless = #{bloom_filter => tls_bloom_filter:new(K, M),
-                         seed => {crypto:strong_rand_bytes(16),
-                                  crypto:strong_rand_bytes(32)},
+                         seed => ssl_config:get_session_ticket_iv_shard(),
                          window => Window},
            lifetime = Lifetime,
            max_early_data_size = MaxEarlyDataSize


### PR DESCRIPTION
This enables configuring the IV and shard used in the `tls_server_session_ticket` `gen_server` for stateless TLS 1.3 session tickets. For example:
```elixir
import Config

config :ssl,
  server_session_ticket_iv: <<1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1>>,
  server_session_ticket_shard: <<2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2>>
```