### PR TITLE
Resumption peer cert

### DIFF
--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -1335,16 +1335,14 @@ decrypt_ticket(CipherFragment, Shard, IV) ->
             HashSize = hash_size(Hash),
             <<PSK:HashSize/binary,?UINT64(TicketAgeAdd),?UINT32(Lifetime),?UINT32(Timestamp),
                 ?UINT16(CertificateLength),Certificate:CertificateLength/binary,_/binary>> = T,
-            Ticket = #stateless_ticket{
+            #stateless_ticket{
                hash = Hash,
                pre_shared_key = PSK,
                ticket_age_add = TicketAgeAdd,
                lifetime = Lifetime,
                timestamp = Timestamp,
                certificate = Certificate
-              },
-            logger:info("~p~n", [Ticket]),
-            Ticket
+            }
     end.
 
 

--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -1334,7 +1334,7 @@ decrypt_ticket(CipherFragment, Shard, IV) ->
             HashSize = hash_size(Hash),
             <<PSK:HashSize/binary,?UINT64(TicketAgeAdd),?UINT32(Lifetime),?UINT32(Timestamp),
                 ?UINT16(CertificateLength),Certificate:CertificateLength/binary,_/binary>> = T,
-            #stateless_ticket{
+            Ticket = #stateless_ticket{
                hash = Hash,
                pre_shared_key = PSK,
                ticket_age_add = TicketAgeAdd,
@@ -1342,7 +1342,9 @@ decrypt_ticket(CipherFragment, Shard, IV) ->
                timestamp = Timestamp,
                certificate_length = CertificateLength,
                certificate = Certificate
-              }
+              },
+            logger:info("~p~n", [Ticket]),
+            Ticket
     end.
 
 

--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -1306,12 +1306,23 @@ encrypt_ticket(#stateless_ticket{
                   pre_shared_key = PSK,
                   ticket_age_add = TicketAgeAdd,
                   lifetime = Lifetime,
-                  timestamp = Timestamp
+                  timestamp = Timestamp,
+                  certificate_length = CertificateLength,
+                  certificate = Certificate
                  }, Shard, IV) ->
     Plaintext = <<(ssl_cipher:hash_algorithm(Hash)):8,PSK/binary,
                    ?UINT64(TicketAgeAdd),?UINT32(Lifetime),?UINT32(Timestamp)>>,
-    encrypt_ticket_data(Plaintext, Shard, IV).
-
+    case CertificateLength of
+        undefined ->
+            Plaintext2 = <<Plaintext/binary,?UINT16(0)>>,
+            encrypt_ticket_data(Plaintext2, Shard, IV);
+        0 ->
+            Plaintext2 = <<Plaintext/binary,?UINT16(0)>>,
+            encrypt_ticket_data(Plaintext2, Shard, IV);
+        _ ->
+            Plaintext2 = <<Plaintext/binary,?UINT16(CertificateLength),Certificate/binary>>,
+            encrypt_ticket_data(Plaintext2, Shard, IV)
+    end.
 
 decrypt_ticket(CipherFragment, Shard, IV) ->
     case decrypt_ticket_data(CipherFragment, Shard, IV) of
@@ -1321,13 +1332,16 @@ decrypt_ticket(CipherFragment, Shard, IV) ->
             <<?BYTE(HKDF),T/binary>> = Plaintext,
             Hash = hash_algorithm(HKDF),
             HashSize = hash_size(Hash),
-            <<PSK:HashSize/binary,?UINT64(TicketAgeAdd),?UINT32(Lifetime),?UINT32(Timestamp),_/binary>> = T,
+            <<PSK:HashSize/binary,?UINT64(TicketAgeAdd),?UINT32(Lifetime),?UINT32(Timestamp),
+                ?UINT16(CertificateLength),Certificate:CertificateLength/binary,_/binary>> = T,
             #stateless_ticket{
                hash = Hash,
                pre_shared_key = PSK,
                ticket_age_add = TicketAgeAdd,
                lifetime = Lifetime,
-               timestamp = Timestamp
+               timestamp = Timestamp,
+               certificate_length = CertificateLength,
+               certificate = Certificate
               }
     end.
 

--- a/lib/ssl/src/ssl_cipher.hrl
+++ b/lib/ssl/src/ssl_cipher.hrl
@@ -34,7 +34,9 @@
          pre_shared_key,
          ticket_age_add,
          lifetime,
-         timestamp
+         timestamp,
+		 certificate_length,
+		 certificate
         }).
 
 %%% SSL cipher protocol  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/ssl/src/ssl_cipher.hrl
+++ b/lib/ssl/src/ssl_cipher.hrl
@@ -35,8 +35,7 @@
          ticket_age_add,
          lifetime,
          timestamp,
-		 certificate_length,
-		 certificate
+         certificate
         }).
 
 %%% SSL cipher protocol  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/ssl/src/tls_handshake_1_3.erl
+++ b/lib/ssl/src/tls_handshake_1_3.erl
@@ -1391,15 +1391,15 @@ maybe_send_session_ticket(State, 0) ->
     State;
 maybe_send_session_ticket(#state{connection_states = ConnectionStates,
                                  static_env = #static_env{trackers = Trackers,
-                                                          protocol_cb = Connection}
-                                 
+                                                          protocol_cb = Connection},
+                                session = #session{peer_certificate = PeerCert}
                                 } = State0, N) ->
     Tracker = proplists:get_value(session_tickets_tracker, Trackers),
     #{security_parameters := SecParamsR} =
         ssl_record:current_connection_state(ConnectionStates, read),
     #security_parameters{prf_algorithm = HKDF,
                          resumption_master_secret = RMS} = SecParamsR, 
-    Ticket = tls_server_session_ticket:new(Tracker, HKDF, RMS),
+    Ticket = tls_server_session_ticket:new(Tracker, HKDF, RMS, PeerCert),
     {State, _} = Connection:send_handshake(Ticket, State0),
     maybe_send_session_ticket(State, N - 1).
 

--- a/lib/ssl/src/tls_handshake_1_3.erl
+++ b/lib/ssl/src/tls_handshake_1_3.erl
@@ -1311,7 +1311,7 @@ session_resumption({#state{ssl_options = #{session_tickets := Tickets},
                                               early_data_accepted = false}} = State0, negotiated}, PSK0)
   when Tickets =/= disabled ->
     State = handle_resumption(State0, ok),
-    {Index, PSK, PeerCert} = PSK0,
+    {Index, PSK, _} = PSK0,
     PSK1 = {Index, PSK},
     {ok, {State, negotiated, PSK1}};
 session_resumption({#state{ssl_options = #{session_tickets := Tickets},
@@ -1520,8 +1520,7 @@ validate_certificate_chain(CertEntries, CertDbHandle, CertDbRef,
                             ocsp_state => OcspState,
                             ocsp_responder_certs => OcspResponderCerts}).
 
-store_peer_cert(#state{session = Session,
-                       handshake_env = HsEnv} = State, PeerCert) ->
+store_peer_cert(#state{session = Session} = State, PeerCert) ->
     State#state{session = Session#session{peer_certificate = PeerCert}}.
 
 store_peer_cert(#state{session = Session,

--- a/lib/ssl/src/tls_handshake_1_3.erl
+++ b/lib/ssl/src/tls_handshake_1_3.erl
@@ -1310,8 +1310,9 @@ session_resumption({#state{ssl_options = #{session_tickets := Tickets},
                            handshake_env = #handshake_env{
                                               early_data_accepted = false}} = State0, negotiated}, PSK0)
   when Tickets =/= disabled ->
-    State = handle_resumption(State0, ok),
-    {Index, PSK, _} = PSK0,
+    State1 = handle_resumption(State0, ok),
+    {Index, PSK, PeerCert} = PSK0,
+    State = store_peer_cert(State1, PeerCert),
     PSK1 = {Index, PSK},
     {ok, {State, negotiated, PSK1}};
 session_resumption({#state{ssl_options = #{session_tickets := Tickets},

--- a/lib/ssl/src/tls_server_session_ticket.erl
+++ b/lib/ssl/src/tls_server_session_ticket.erl
@@ -327,7 +327,6 @@ generate_stateless_ticket(#new_session_ticket{ticket_nonce = Nonce,
                          #state{stateless = #{seed := {IV, Shard}}}) ->
     PSK = tls_v1:pre_shared_key(MasterSecret, Nonce, Prf),
     Timestamp = erlang:system_time(second),
-    logger:info("Cert to put in ticket: ~s", [PeerCert]),
     Encrypted = ssl_cipher:encrypt_ticket(#stateless_ticket{
                                     hash = Prf,
                                     pre_shared_key = PSK,

--- a/lib/ssl/src/tls_server_session_ticket.erl
+++ b/lib/ssl/src/tls_server_session_ticket.erl
@@ -328,30 +328,15 @@ generate_stateless_ticket(#new_session_ticket{ticket_nonce = Nonce,
     PSK = tls_v1:pre_shared_key(MasterSecret, Nonce, Prf),
     Timestamp = erlang:system_time(second),
     logger:info("Cert to put in ticket: ~s", [PeerCert]),
-    case PeerCert of
-        undefined ->
-            Encrypted = ssl_cipher:encrypt_ticket(#stateless_ticket{
-                                            hash = Prf,
-                                            pre_shared_key = PSK,
-                                            ticket_age_add = TicketAgeAdd,
-                                            lifetime = Lifetime,
-                                            timestamp = Timestamp,
-                                            certificate_length = undefined,
-                                            certificate = undefined
-                                            }, Shard, IV),
-            Ticket#new_session_ticket{ticket = Encrypted};
-        _ ->
-            Encrypted = ssl_cipher:encrypt_ticket(#stateless_ticket{
-                                            hash = Prf,
-                                            pre_shared_key = PSK,
-                                            ticket_age_add = TicketAgeAdd,
-                                            lifetime = Lifetime,
-                                            timestamp = Timestamp,
-                                            certificate_length = byte_size(PeerCert),
-                                            certificate = PeerCert
-                                            }, Shard, IV),
-            Ticket#new_session_ticket{ticket = Encrypted}
-    end.
+    Encrypted = ssl_cipher:encrypt_ticket(#stateless_ticket{
+                                    hash = Prf,
+                                    pre_shared_key = PSK,
+                                    ticket_age_add = TicketAgeAdd,
+                                    lifetime = Lifetime,
+                                    timestamp = Timestamp,
+                                    certificate = PeerCert
+                                    }, Shard, IV),
+    Ticket#new_session_ticket{ticket = Encrypted}.
 
 stateless_use(#offered_psks{
                  identities = Identities,

--- a/lib/ssl/src/tls_server_session_ticket.erl
+++ b/lib/ssl/src/tls_server_session_ticket.erl
@@ -81,7 +81,7 @@ init([Listener | Args]) ->
 
 -spec handle_call(Request :: term(), From :: {pid(), term()}, State :: term()) ->
                          {reply, Reply :: term(), NewState :: term()} .
-handle_call({new_session_ticket, Prf, MasterSecret, _PeerCert}, _From, 
+handle_call({new_session_ticket, Prf, MasterSecret, _}, _From,
             #state{nonce = Nonce, 
                    lifetime = LifeTime,
                    max_early_data_size = MaxEarlyDataSize,

--- a/lib/ssl/src/tls_server_session_ticket.erl
+++ b/lib/ssl/src/tls_server_session_ticket.erl
@@ -327,6 +327,7 @@ generate_stateless_ticket(#new_session_ticket{ticket_nonce = Nonce,
                          #state{stateless = #{seed := {IV, Shard}}}) ->
     PSK = tls_v1:pre_shared_key(MasterSecret, Nonce, Prf),
     Timestamp = erlang:system_time(second),
+    logger:info("Cert to put in ticket: ", #{ meta => PeerCert }),
     case PeerCert of
         undefined ->
             Encrypted = ssl_cipher:encrypt_ticket(#stateless_ticket{

--- a/lib/ssl/src/tls_server_session_ticket.erl
+++ b/lib/ssl/src/tls_server_session_ticket.erl
@@ -96,7 +96,7 @@ handle_call({new_session_ticket, Prf, MasterSecret, PeerCert}, _From,
                    stateless = #{}} = State) -> 
     BaseSessionTicket = new_session_ticket_base(State),
     SessionTicket = generate_stateless_ticket(BaseSessionTicket, Prf, 
-                                              MasterSecret, State, PeerCert),
+                                              MasterSecret, PeerCert, State),
     {reply, SessionTicket, State#state{nonce = Nonce+1}};
 handle_call({use_ticket, Identifiers, Prf, HandshakeHist}, _From, 
             #state{stateful = #{}} = State0) -> 

--- a/lib/ssl/src/tls_server_session_ticket.erl
+++ b/lib/ssl/src/tls_server_session_ticket.erl
@@ -327,7 +327,7 @@ generate_stateless_ticket(#new_session_ticket{ticket_nonce = Nonce,
                          #state{stateless = #{seed := {IV, Shard}}}) ->
     PSK = tls_v1:pre_shared_key(MasterSecret, Nonce, Prf),
     Timestamp = erlang:system_time(second),
-    logger:info("Cert to put in ticket: ", #{ meta => PeerCert }),
+    logger:info("Cert to put in ticket: ~s", [PeerCert]),
     case PeerCert of
         undefined ->
             Encrypted = ssl_cipher:encrypt_ticket(#stateless_ticket{


### PR DESCRIPTION
If `peer_certificate` is not `undefined` add it to the TLS 1.3 stateless ticket.

When receiving a stateless ticket with the certificate, store it in the `peer_certificate` field.